### PR TITLE
add printing for ParameterJuMP.ParametrizedAffExpr

### DIFF
--- a/src/ParameterJuMP.jl
+++ b/src/ParameterJuMP.jl
@@ -530,7 +530,7 @@ function delete_from_constraints(::Type{S}, param::Parameter) where S
         end
     end
     if lazy_duals(data)
-        if !isempty(data.constraints_map[param.ind]) 
+        if !isempty(data.constraints_map[param.ind])
             data.constraints_map[param.ind] = ParametrizedConstraintRef[]
             if !iszero(data.future_values[param.ind])
                 data.sync = false
@@ -553,5 +553,5 @@ end
 
 include("operators.jl")
 include("mutable_arithmetics.jl")
-
+include("print.jl")
 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -1,0 +1,3 @@
+function JuMP.function_string(mode, a::ParameterJuMP.ParametrizedAffExpr, show_constant=true)
+    return JuMP.function_string(mode, a.v, show_constant)
+end


### PR DESCRIPTION
Overloading `JuMP.function_string` fixes #37. It won't print the parameter but will resolve the error. 