### PR TITLE
[deprecations] Simplify the API of ParameterJuMP

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -4,13 +4,16 @@ struct ParameterValue{T} <: JuMP.AbstractVariable
     value::T
 end
 
-_invalid_init_error(msg) = error("Invalid initialization of parameter. " * msg * " not supported.")
+function _invalid_init_msg(msg)
+    return "Invalid initialization of parameter. " * msg * " not supported."
+end
+
 function JuMP.build_variable(_error::Function, info::JuMP.VariableInfo, ::Param)
-    info.has_lb && _invalid_init_error("Lower bound")
-    info.has_ub && _invalid_init_error("Upper bound")
-    info.binary && _invalid_init_error("Binary")
-    info.integer && _invalid_init_error("Integer")
-    info.has_start && _invalid_init_error("Initial value")
+    info.has_lb && _error(_invalid_init_msg("Lower bound"))
+    info.has_ub && _error(_invalid_init_msg("Upper bound"))
+    info.binary && _error(_invalid_init_msg("Binary"))
+    info.integer && _error(_invalid_init_msg("Integer"))
+    info.has_start && _error(_invalid_init_msg("Initial value"))
     if !info.has_fix
         return ParameterValue(0.0)
     else

--- a/src/variable_interface.jl
+++ b/src/variable_interface.jl
@@ -1,40 +1,29 @@
-
-# JuMP Variable interface
-# ------------------------------------------------------------------------------
-
-# main interface
-
-JuMP.is_fixed(p::ParameterRef) = true
-JuMP.FixRef(p::ParameterRef) =
-    error("Parameters do not have have explicit constraints, hence no constraint reference.")
-JuMP.unfix(p::ParameterRef) = error("Parameters cannot be unfixed.")
-
-function JuMP.fix(p::ParameterRef, val::Real)
-    data = _getparamdata(p)::ParameterData
-    data.sync = false
-    data.future_values[index(data, p)] = val
-    return nothing
+function JuMP.fix(p::ParameterRef, v::Real)
+    @warn("fix is deprecated. Use `set_value(p, v)` instead.")
+    return set_value(p, v)
 end
 
-
 """
-    fix(p::ParameterRef, val::Real)::Nothing
+    set_value(p::ParameterRef, value::Real)
 
-Sets the parameter `p` to the new value `val`.
+Sets the parameter `p` to the new value `value`.
 """
-function fix(p::ParameterRef, val::Real)
+function JuMP.set_value(p::ParameterRef, value::Real)
     params = _getparamdata(p)::ParameterData
     params.sync = false
-    params.future_values[index(p)] = val
+    params.future_values[index(p)] = value
     return nothing
 end
 
+"""
+    value(p::ParameterRef)
+
+Return the current value of the parameter `p`.
+"""
 function JuMP.value(p::ParameterRef)
     data = _getparamdata(p)::ParameterData
     data.future_values[index(data, p)]
 end
-
-# interface continues
 
 JuMP.owner_model(p::ParameterRef) = p.model
 
@@ -50,27 +39,6 @@ end
 
 Base.iszero(::ParameterRef) = false
 Base.copy(p::ParameterRef) = ParameterRef(p.ind, p.model)
-# Base.broadcastable(v::VariableRef) = Ref(v) # NEEDED???
-
-"""
-    delete(model::Model, param::ParameterRef)
-
-Delete the parameter `param` from the model `model`.
-
-Note.
-After the first deletion you might experience performance reduction.
-Therefore, only use thid command if there is no other way around.
-"""
-function JuMP.delete(model::Model, param::ParameterRef)
-    error("Parameters can be deleted currently.")
-    if model !== owner_model(param)
-        error("The variable reference you are trying to delete does not " *
-              "belong to the model.")
-    end
-    # create dictionary map
-    # turn flag has_deleted
-    # delete names ?
-end
 
 """
     is_valid(model::Model, parameter::ParameterRef)
@@ -91,22 +59,15 @@ function Base.isequal(p1::ParameterRef, p2::ParameterRef)
     return owner_model(p1) === owner_model(p2) && p1.ind == p2.ind
 end
 
-function JuMP.name(p::ParameterRef)
-    dict = _getparamdata(p).names
-    if haskey(dict, p)
-        return dict[p]
-    else
-        return ""
-    end
-end
+JuMP.name(p::ParameterRef) = get(_getparamdata(p).names, p, "")
 
 function JuMP.set_name(p::ParameterRef, s::String)
     dict = _getparamdata(p).names
     dict[p] = s
+    return s
 end
 
 function parameter_by_name(model::Model, name::String)
-    # can be improved with a lazy rev_names map
     dict = _getparamdata(model).names
     for (par, n) in dict
         if n == name
@@ -115,44 +76,3 @@ function parameter_by_name(model::Model, name::String)
     end
     return nothing
 end
-
-JuMP.has_lower_bound(p::ParameterRef) = false
-JuMP.LowerBoundRef(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.set_lower_bound(p::ParameterRef, lower::Number) =
-    error("Parameters do not have bounds.")
-JuMP.delete_lower_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.lower_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-
-JuMP.has_upper_bound(p::ParameterRef) = false
-JuMP.UpperBoundRef(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.set_upper_bound(p::ParameterRef, lower::Number) =
-    error("Parameters do not have bounds.")
-JuMP.delete_upper_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.upper_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-
-JuMP.is_integer(p::ParameterRef) = false
-JuMP.set_integer(p::ParameterRef) =
-    error("Parameters do not have integrality constraints.")
-JuMP.unset_integer(p::ParameterRef) =
-    error("Parameters do not have integrality constraints.")
-JuMP.IntegerRef(p::ParameterRef) =
-    error("Parameters do not have integrality constraints.")
-
-JuMP.is_binary(p::ParameterRef) = false
-JuMP.set_binary(p::ParameterRef) =
-    error("Parameters do not have binary constraints.")
-JuMP.unset_binary(p::ParameterRef) =
-    error("Parameters do not have binary constraints.")
-JuMP.BinaryRef(p::ParameterRef) =
-    error("Parameters do not have binary constraints.")
-
-JuMP.start_value(p::ParameterRef) =
-    error("Parameters do not have start values.")
-JuMP.set_start_value(p::ParameterRef, value::Number) =
-    error("Parameters do not have start values.")


### PR DESCRIPTION
Surprisingly, this is the first time I've ever dug into the ParameterJuMP code. I'm not in a rush to merge this, because it adds deprecation warnings, but the main changes are:
* Remove the need for ModelWithParams
* Document and test the macro syntax for adding parameters
* Switch `fix` for `set_value` to match `@NLparameters` in JuMP
* Removes functions we don't need to implement. Better to just throw a method error for functions users call directly.

I got a bit carried away, so I can split this up into four separate PRs if you prefer.