### PR TITLE
[deprecation] Remove fix in favor of set_value

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ It is possible to change the current value of a parameter with the
 function:
 
 ```julia
-fix(p::ParameterRef, new_value::Number)
+set_value(p::ParameterRef, new_value::Number)
+```
+Query the current value of the parameter with:
+```julia
+value(p::ParameterRef)
 ```
 
 Finally, the `dual` function of JuMP is overloaded to return duals
@@ -102,7 +106,7 @@ optimize!(model)
 dual(a)
 
 # modify the value of the parameter a to 20
-fix(a, 20)
+set_value(a, 20)
 
 # solve the model with the new value of the parameter
 optimize!(model)
@@ -172,7 +176,7 @@ optimize!(model_pure)
 y_duals = dual.(fix_y)
 
 # modify y
-fix.(y_fixed, new_value_for_y)
+set_value.(y_fixed, new_value_for_y)
 
 # solve problem (again)
 optimize!(model_pure)
@@ -216,7 +220,7 @@ optimize!(model_param)
 y_duals = dual.(y)
 
 # modify y
-fix.(y, new_value_for_y)
+set_value.(y, new_value_for_y)
 
 # solve problem (again)
 optimize!(model_param)

--- a/src/ParameterJuMP.jl
+++ b/src/ParameterJuMP.jl
@@ -357,4 +357,6 @@ include("mutable_arithmetics.jl")
 include("macros.jl")
 include("print.jl")
 
+include("deprecations.jl")
+
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,5 +1,8 @@
 function JuMP.fix(p::ParameterRef, val::Real)
-    @warn("JuMP.fix has been deprecated. Use `set_value(p, v)` instead.")
+    @warn(
+        "JuMP.fix has been deprecated. Use `set_value(p, v)` instead.",
+        maxlog = 1,
+    )
     return set_value(p, val)
 end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,4 @@
+function JuMP.fix(p::ParameterRef, val::Real)
+    @warn("JuMP.fix has been deprecated. Use `set_value(p, v)` instead.")
+    return set_value(p, val)
+end

--- a/src/variable_interface.jl
+++ b/src/variable_interface.jl
@@ -1,8 +1,3 @@
-function JuMP.fix(p::ParameterRef, val::Real)
-    @warn("JuMP.fix has been deprecated. Use `set_value(p, v)` instead.")
-    return set_value(p, val)
-end
-
 """
     set_value(p::ParameterRef, val::Real)
 

--- a/src/variable_interface.jl
+++ b/src/variable_interface.jl
@@ -22,7 +22,7 @@ Return the current value of the parameter `p`.
 """
 function JuMP.value(p::ParameterRef)
     data = _getparamdata(p)::_ParameterData
-    return data.future_values[index(data, p)]
+    return data.future_values[index(p)]
 end
 
 # interface continues

--- a/src/variable_interface.jl
+++ b/src/variable_interface.jl
@@ -1,37 +1,28 @@
-
-# JuMP Variable interface
-# ------------------------------------------------------------------------------
-
-# main interface
-
-JuMP.is_fixed(p::ParameterRef) = true
-JuMP.FixRef(p::ParameterRef) =
-    error("Parameters do not have have explicit constraints, hence no constraint reference.")
-JuMP.unfix(p::ParameterRef) = error("Parameters cannot be unfixed.")
-
 function JuMP.fix(p::ParameterRef, val::Real)
-    data = _getparamdata(p)::ParameterData
-    data.sync = false
-    data.future_values[index(data, p)] = val
-    return nothing
+    @warn("JuMP.fix has been deprecated. Use `set_value(p, v)` instead.")
+    return set_value(p, val)
 end
 
-
 """
-    fix(p::ParameterRef, val::Real)::Nothing
+    set_value(p::ParameterRef, val::Real)
 
 Sets the parameter `p` to the new value `val`.
 """
-function fix(p::ParameterRef, val::Real)
+function JuMP.set_value(p::ParameterRef, val::Real)
     params = _getparamdata(p)::ParameterData
     params.sync = false
     params.future_values[index(p)] = val
-    return nothing
+    return val
 end
 
+"""
+    value(p::ParameterRef)
+
+Return the current value of the parameter `p`.
+"""
 function JuMP.value(p::ParameterRef)
     data = _getparamdata(p)::ParameterData
-    data.future_values[index(data, p)]
+    return data.future_values[index(data, p)]
 end
 
 # interface continues
@@ -50,27 +41,6 @@ end
 
 Base.iszero(::ParameterRef) = false
 Base.copy(p::ParameterRef) = ParameterRef(p.ind, p.model)
-# Base.broadcastable(v::VariableRef) = Ref(v) # NEEDED???
-
-"""
-    delete(model::Model, param::ParameterRef)
-
-Delete the parameter `param` from the model `model`.
-
-Note.
-After the first deletion you might experience performance reduction.
-Therefore, only use thid command if there is no other way around.
-"""
-function JuMP.delete(model::Model, param::ParameterRef)
-    error("Parameters can be deleted currently.")
-    if model !== owner_model(param)
-        error("The variable reference you are trying to delete does not " *
-              "belong to the model.")
-    end
-    # create dictionary map
-    # turn flag has_deleted
-    # delete names ?
-end
 
 """
     is_valid(model::Model, parameter::ParameterRef)
@@ -91,19 +61,8 @@ function Base.isequal(p1::ParameterRef, p2::ParameterRef)
     return owner_model(p1) === owner_model(p2) && p1.ind == p2.ind
 end
 
-function JuMP.name(p::ParameterRef)
-    dict = _getparamdata(p).names
-    if haskey(dict, p)
-        return dict[p]
-    else
-        return ""
-    end
-end
-
-function JuMP.set_name(p::ParameterRef, s::String)
-    dict = _getparamdata(p).names
-    dict[p] = s
-end
+JuMP.name(p::ParameterRef) = get(_getparamdata(p).names, p, "")
+JuMP.set_name(p::ParameterRef, s::String) = _getparamdata(p).names[p] = s
 
 function parameter_by_name(model::Model, name::String)
     # can be improved with a lazy rev_names map
@@ -115,44 +74,3 @@ function parameter_by_name(model::Model, name::String)
     end
     return nothing
 end
-
-JuMP.has_lower_bound(p::ParameterRef) = false
-JuMP.LowerBoundRef(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.set_lower_bound(p::ParameterRef, lower::Number) =
-    error("Parameters do not have bounds.")
-JuMP.delete_lower_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.lower_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-
-JuMP.has_upper_bound(p::ParameterRef) = false
-JuMP.UpperBoundRef(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.set_upper_bound(p::ParameterRef, lower::Number) =
-    error("Parameters do not have bounds.")
-JuMP.delete_upper_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-JuMP.upper_bound(p::ParameterRef) =
-    error("Parameters do not have bounds.")
-
-JuMP.is_integer(p::ParameterRef) = false
-JuMP.set_integer(p::ParameterRef) =
-    error("Parameters do not have integrality constraints.")
-JuMP.unset_integer(p::ParameterRef) =
-    error("Parameters do not have integrality constraints.")
-JuMP.IntegerRef(p::ParameterRef) =
-    error("Parameters do not have integrality constraints.")
-
-JuMP.is_binary(p::ParameterRef) = false
-JuMP.set_binary(p::ParameterRef) =
-    error("Parameters do not have binary constraints.")
-JuMP.unset_binary(p::ParameterRef) =
-    error("Parameters do not have binary constraints.")
-JuMP.BinaryRef(p::ParameterRef) =
-    error("Parameters do not have binary constraints.")
-
-JuMP.start_value(p::ParameterRef) =
-    error("Parameters do not have start values.")
-JuMP.set_start_value(p::ParameterRef, value::Number) =
-    error("Parameters do not have start values.")

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -70,7 +70,7 @@ end
 function test_lessthan(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x ≤ α)
     @objective(model, Max, x)
@@ -80,7 +80,7 @@ function test_lessthan(args...)
     @test JuMP.dual(α) == -1.0
     @test parametrized_dual_objective_value(model) ≈ -α - 2 atol=1e-3
 
-    fix(α, 2.0)
+    set_value(α, 2.0)
     JuMP.optimize!(model)
     @test JuMP.value(x) == 2.0
     @test JuMP.dual(cref) == -1.0
@@ -91,7 +91,7 @@ end
 function test_equalto(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x == α)
     @objective(model, Max, x)
@@ -101,7 +101,7 @@ function test_equalto(args...)
     @test JuMP.dual(α) == -1.0
     @test parametrized_dual_objective_value(model) ≈ -α - 2 atol=1e-3
 
-    fix(α, 2.0)
+    set_value(α, 2.0)
     JuMP.optimize!(model)
     @test JuMP.value(x) == 2.0
     @test JuMP.dual(cref) == -1.0
@@ -112,7 +112,7 @@ end
 function test_greaterthan(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x >= α)
     @objective(model, Min, x)
@@ -122,7 +122,7 @@ function test_greaterthan(args...)
     @test JuMP.dual(α) == 1.0
     @test parametrized_dual_objective_value(model) ≈ 1α
 
-    fix(α, 2.0)
+    set_value(α, 2.0)
     JuMP.optimize!(model)
     @test JuMP.value(x) == 2.0
     @test JuMP.dual(cref) == 1.0
@@ -207,7 +207,7 @@ end
 function test_add_after_solve(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x <= α)
     @objective(model, Max, x)
@@ -251,7 +251,7 @@ end
 function test_change_coefficient(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x >= α)
     @objective(model, Min, x)
@@ -317,7 +317,7 @@ end
 function test_remove_parameter_constraint(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x >= α)
     @objective(model, Min, x)
@@ -338,7 +338,7 @@ end
 function test_remove_parameter_all_constraints(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x >= α)
     @objective(model, Min, x)
@@ -360,7 +360,7 @@ function test_no_duals(args...)
     model = ModelWithParams(args...)
     ParameterJuMP.set_no_duals(model)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     cref = @constraint(model, x == α)
     @objective(model, Max, x)
@@ -443,7 +443,7 @@ end
 function test_add_ctr_alaternative(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
-    fix(α, -1.0)
+    set_value(α, -1.0)
     @variable(model, x)
     exp = x - α
     cref = @constraint(model, exp ≤ 0)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -70,7 +70,9 @@ end
 function test_lessthan(args...)
     model = ModelWithParams(args...)
     α = add_parameter(model, 1.0)
+    @test value(α) == 1.0
     set_value(α, -1.0)
+    @test value(α) == -1.0
     @variable(model, x)
     cref = @constraint(model, x ≤ α)
     @objective(model, Max, x)


### PR DESCRIPTION
JuMP's Nonlinear parameters use `set_value` and `value`: https://jump.dev/JuMP.jl/stable/nlp/#Nonlinear-Parameters

We should follow that.