### PR TITLE
Tidy ParameterData

### DIFF
--- a/src/ParameterJuMP.jl
+++ b/src/ParameterJuMP.jl
@@ -7,9 +7,6 @@ const MA = MutableArithmetics
 
 using JuMP
 export index
-using MathOptInterface
-const MOI = MathOptInterface
-const MOIU = MOI.Utilities
 
 export
 ModelWithParams, ParameterRef, add_parameter, add_parameters, all_parameters, Param, parametrized_dual_objective_value
@@ -27,71 +24,59 @@ struct ParametrizedConstraintRef{C}
     coef::Float64
 end
 
-const CtrRef{F, S} = ConstraintRef{JuMP.Model,MOI.ConstraintIndex{F,S}, JuMP.ScalarShape}
+const CtrRef{F,S} = ConstraintRef{JuMP.Model,MOI.ConstraintIndex{F,S},JuMP.ScalarShape}
 const SAF = MOI.ScalarAffineFunction{Float64}
-const EQ = MOI.EqualTo{Float64}
-const LE = MOI.LessThan{Float64}
-const GE = MOI.GreaterThan{Float64}
 
-mutable struct ParameterData
+mutable struct _ParameterData
     inds::Vector{Int64}
     next_ind::Int64
-
     current_values::Vector{Float64}
     future_values::Vector{Float64}
-
     # Whether the JuMP model is in sync with the value of the parameters
     sync::Bool
-
     # constraints where it is a RHS
-    constraints_map::Dict{Int64, Vector{ParametrizedConstraintRef}}
-
-    parameters_map_saf_in_eq::Dict{CtrRef{SAF, EQ}, JuMP.GenericAffExpr{Float64,ParameterRef}}
-    parameters_map_saf_in_le::Dict{CtrRef{SAF, LE}, JuMP.GenericAffExpr{Float64,ParameterRef}}
-    parameters_map_saf_in_ge::Dict{CtrRef{SAF, GE}, JuMP.GenericAffExpr{Float64,ParameterRef}}
-
-    names::Dict{ParameterRef, String}
-
-    # overload addvariable
-    # variables_map::Dict{Int64, Vector{Int64}}
-    # variables_map_lb::Dict{Int64, Vector{Int64}}
-    # variables_map_ub::Dict{Int64, Vector{Int64}}
-
-    # solved::Bool
-
-    has_deletion::Bool
-    index_map::Dict{Int64, Int64}
-
-
+    constraints_map::Dict{Int64,Vector{ParametrizedConstraintRef}}
+    parameters_map_saf_in_eq::Dict{
+        CtrRef{SAF,MOI.EqualTo{Float64}},
+        JuMP.GenericAffExpr{Float64,ParameterRef},
+    }
+    parameters_map_saf_in_le::Dict{
+        CtrRef{SAF,MOI.LessThan{Float64}},
+        JuMP.GenericAffExpr{Float64,ParameterRef},
+    }
+    parameters_map_saf_in_ge::Dict{
+        CtrRef{SAF,MOI.GreaterThan{Float64}},
+        JuMP.GenericAffExpr{Float64,ParameterRef},
+    }
+    names::Dict{ParameterRef,String}
     lazy::Bool
-
     no_duals::Bool
     dual_values::Vector{Float64}
-    function ParameterData()
-        new(Int64[],
+
+    function _ParameterData()
+        return new(
+            Int64[],
             1,
             Float64[],
             Float64[],
             true,
-            Dict{Int64, Vector{JuMP.ConstraintRef}}(),
-            Dict{CtrRef{SAF, EQ}, JuMP.GenericAffExpr{Float64,ParameterRef}}(),
-            Dict{CtrRef{SAF, LE}, JuMP.GenericAffExpr{Float64,ParameterRef}}(),
-            Dict{CtrRef{SAF, GE}, JuMP.GenericAffExpr{Float64,ParameterRef}}(),
-            Dict{ParameterRef, String}(),
-            false,
-            Dict{Int64, Int64}(),
+            Dict{Int64,Vector{JuMP.ConstraintRef}}(),
+            Dict{CtrRef{SAF,MOI.EqualTo{Float64}},JuMP.GenericAffExpr{Float64,ParameterRef}}(),
+            Dict{CtrRef{SAF,MOI.LessThan{Float64}},JuMP.GenericAffExpr{Float64,ParameterRef}}(),
+            Dict{CtrRef{SAF,MOI.GreaterThan{Float64}},JuMP.GenericAffExpr{Float64,ParameterRef}}(),
+            Dict{ParameterRef,String}(),
             false,
             false,
-            Float64[]
-            )
+            Float64[],
+        )
     end
 end
 
-no_duals(data::ParameterData) = data.no_duals
+no_duals(data::_ParameterData) = data.no_duals
 no_duals(model::JuMP.Model) = no_duals(_getparamdata(model))
 
 set_no_duals(model::JuMP.Model) = set_no_duals(_getparamdata(model))
-function set_no_duals(data::ParameterData)
+function set_no_duals(data::_ParameterData)
     if isempty(data.current_values)
         data.no_duals = true
     elseif no_duals(data)
@@ -106,21 +91,13 @@ end
 
 Return the internal index of the parameter `p`.
 """
-JuMP.index(p::ParameterRef) = index(_getparamdata(p.model), p)::Int64
-JuMP.index(model::JuMP.Model, p::ParameterRef) = index(_getparamdata(model), p)::Int64
-function JuMP.index(data::ParameterData, p::ParameterRef)::Int64
-    if data.has_deletion
-        return data.index_map[p.ind]
-    else
-        return p.ind
-    end
-end
+JuMP.index(p::ParameterRef) = p.ind
 
-lazy_duals(data::ParameterData) = data.lazy
+lazy_duals(data::_ParameterData) = data.lazy
 lazy_duals(model::JuMP.Model) = lazy_duals(_getparamdata(model))
 
 set_lazy_duals(model::JuMP.Model) = set_lazy_duals(_getparamdata(model))
-function set_lazy_duals(data::ParameterData)
+function set_lazy_duals(data::_ParameterData)
     if isempty(data.current_values)
         data.lazy = true
     elseif lazy_duals(data)
@@ -131,7 +108,7 @@ function set_lazy_duals(data::ParameterData)
 end
 
 set_not_lazy_duals(model::JuMP.Model) = set_not_lazy_duals(_getparamdata(model))
-function set_not_lazy_duals(data::ParameterData)
+function set_not_lazy_duals(data::_ParameterData)
     if isempty(data.current_values)
         data.lazy = false
     elseif !lazy_duals(data)
@@ -141,14 +118,22 @@ function set_not_lazy_duals(data::ParameterData)
     end
 end
 
-_get_param_dict(data::ParameterData, ::Type{EQ}) = data.parameters_map_saf_in_eq
-_get_param_dict(data::ParameterData, ::Type{LE}) = data.parameters_map_saf_in_le
-_get_param_dict(data::ParameterData, ::Type{GE}) = data.parameters_map_saf_in_ge
+function _get_param_dict(data::_ParameterData, ::Type{MOI.EqualTo{Float64}})
+    return data.parameters_map_saf_in_eq
+end
+
+function _get_param_dict(data::_ParameterData, ::Type{MOI.LessThan{Float64}})
+    return data.parameters_map_saf_in_le
+end
+
+function _get_param_dict(data::_ParameterData, ::Type{MOI.GreaterThan{Float64}})
+    return data.parameters_map_saf_in_ge
+end
 
 _getmodel(p::ParameterRef) = p.model
-_getparamdata(p::ParameterRef)::ParameterData = _getparamdata(_getmodel(p))::ParameterData
-# _getparamdata(model::JuMP.Model) = model.ext[:params]::ParameterData
-function _getparamdata(model::JuMP.Model)::ParameterData
+_getparamdata(p::ParameterRef)::_ParameterData = _getparamdata(_getmodel(p))::_ParameterData
+# _getparamdata(model::JuMP.Model) = model.ext[:params]::_ParameterData
+function _getparamdata(model::JuMP.Model)::_ParameterData
     # TODO checks dict twice
     !haskey(model.ext, :params) && error("In order to use Parameters the model must be created with the ModelWithParams constructor")
     return model.ext[:params]
@@ -159,7 +144,7 @@ end
 
 Test if the JuMP Model is updated to the latest value of all parameters.
 """
-is_sync(data::ParameterData) = data.sync
+is_sync(data::_ParameterData) = data.sync
 is_sync(model::JuMP.Model) = is_sync(_getparamdata(model))
 
 """
@@ -172,7 +157,7 @@ Adds one parameter fixed at `val` to the model `model`.
 Adds one parameter fixed at zero to the model `model`.
 """
 function add_parameter(model::JuMP.Model, val::Real)
-    params = _getparamdata(model)::ParameterData
+    params = _getparamdata(model)::_ParameterData
 
     ind = params.next_ind
     params.next_ind += 1
@@ -206,7 +191,7 @@ function add_parameters(model::JuMP.Model, N::Integer)
     return add_parameters(model::JuMP.Model, zeros(N))
 end
 function add_parameters(model::JuMP.Model, val::AbstractArray{R,N}) where {R,N}
-    params = _getparamdata(model)::ParameterData
+    params = _getparamdata(model)::_ParameterData
 
     nparam = length(val)
     out = ParameterRef[]
@@ -287,13 +272,13 @@ function enable_parameters(m::JuMP.Model)
 end
 
 function initialize_parameter_data(m::JuMP.Model)
-    m.ext[:params] = ParameterData()
+    m.ext[:params] = _ParameterData()
 end
 
 # The constraint has been deleted. We cannot keep `dict` in sync with deletions
 # as we return a `JuMP.ConstraintRef`, not a custom type when the user create a
 # parametrized constraint.
-function _update_dicts_with_deletion(data::ParameterData, S::Type)
+function _update_dicts_with_deletion(data::_ParameterData, S::Type)
     dict = _get_param_dict(data, S)
     to_delete = eltype(keys(dict))[]
     for (cref, gaep) in dict
@@ -305,13 +290,13 @@ function _update_dicts_with_deletion(data::ParameterData, S::Type)
         delete!(dict, cref)
     end
 end
-function _update_dicts_with_deletion(data::ParameterData)
-    _update_dicts_with_deletion(data, EQ)
-    _update_dicts_with_deletion(data, LE)
-    _update_dicts_with_deletion(data, GE)
+function _update_dicts_with_deletion(data::_ParameterData)
+    _update_dicts_with_deletion(data, MOI.EqualTo{Float64})
+    _update_dicts_with_deletion(data, MOI.LessThan{Float64})
+    _update_dicts_with_deletion(data, MOI.GreaterThan{Float64})
 end
 function parameter_optimizehook(m::JuMP.Model; kwargs...)
-    data = _getparamdata(m)::ParameterData
+    data = _getparamdata(m)::_ParameterData
 
     _update_dicts_with_deletion(data)
 
@@ -333,7 +318,7 @@ end
 Forces the model to update its constraints to the new values of the
 Parameters.
 """
-function sync(data::ParameterData)
+function sync(data::_ParameterData)
     if !is_sync(data)
         _update_constraints(data)
         data.current_values .= data.future_values

--- a/src/variable_interface.jl
+++ b/src/variable_interface.jl
@@ -10,9 +10,9 @@ JuMP.FixRef(p::ParameterRef) =
 JuMP.unfix(p::ParameterRef) = error("Parameters cannot be unfixed.")
 
 function JuMP.fix(p::ParameterRef, val::Real)
-    data = _getparamdata(p)::ParameterData
+    data = _getparamdata(p)::_ParameterData
     data.sync = false
-    data.future_values[index(data, p)] = val
+    data.future_values[index(p)] = val
     return nothing
 end
 
@@ -23,15 +23,15 @@ end
 Sets the parameter `p` to the new value `val`.
 """
 function fix(p::ParameterRef, val::Real)
-    params = _getparamdata(p)::ParameterData
+    params = _getparamdata(p)::_ParameterData
     params.sync = false
     params.future_values[index(p)] = val
     return nothing
 end
 
 function JuMP.value(p::ParameterRef)
-    data = _getparamdata(p)::ParameterData
-    data.future_values[index(data, p)]
+    data = _getparamdata(p)::_ParameterData
+    data.future_values[index(p)]
 end
 
 # interface continues


### PR DESCRIPTION
ParameterData contained un-used fields like `index_map` and `has_deletion`.